### PR TITLE
feature: Edit Contact Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,35 @@
 # Contact Management React
 
-npm run dev
+Basic React Project that allows users to create, edit and delete users in a session.
 
+## Run Locally
+
+Clone the project
+
+```bash
+  git clone https://github.com/mattzbik/contact-management-react.git
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Go to the project directory
 
+```bash
+  cd contact-management-react
+```
+
+Install dependencies
+
+```bash
+  npm install
+```
+
+Start the server
+
+```bash
+  npm run dev
+```
+
+Open in browser
+
+```bash
+http://localhost:3000 with your browser to see the result.
 ```

--- a/src/app/create/contact/page.tsx
+++ b/src/app/create/contact/page.tsx
@@ -1,150 +1,19 @@
 'use client';
-import { InputField } from '@/components/InputField';
+import ContactInformation from '@/components/ContactInformation';
 import { DataContext } from '@/context/context';
 import { Contact } from '@/models/contact';
-import {
-  Alert,
-  AlertTitle,
-  Box,
-  Button,
-  Grid,
-  Typography,
-} from '@mui/material';
 import React, { useContext } from 'react';
-import { SubmitHandler, useForm } from 'react-hook-form';
+import { SubmitHandler } from 'react-hook-form';
 
 export const CreateContact: React.FC = () => {
   const { contacts, setContacts } = useContext(DataContext);
-  const formReturnValues = useForm<Contact>({
-    defaultValues: { firstName: '', lastName: '', email: '' },
-  });
-
-  const { formState, handleSubmit, setError, control, ...rest } =
-    formReturnValues;
-  const { isSubmitting, errors } = formState;
-
-  const onSubmit: SubmitHandler<Contact> = async (data) => {
+  const onSubmit: SubmitHandler<Contact> = (data) => {
     data.id = contacts.length + 1;
-    for (let c of contacts) {
-      if (c.email === data.email) {
-        setError('email', { type: 'custom', message: 'Email exists' });
-        return;
-      }
-    }
+
     setContacts([...contacts, data]);
   };
-  const isErrorsEmpty = Object.keys(errors).length === 0;
 
-  return (
-    <Grid container>
-      <Grid item xs={12}>
-        <Typography variant="h1">Create New Contact</Typography>
-        <Box component="form" width="100%" onSubmit={handleSubmit(onSubmit)}>
-          <Grid
-            container
-            spacing={2}
-            alignItems="center"
-            justifyContent="space-between"
-          >
-            <Grid item xs={12} md={3}>
-              <InputField
-                label="First Name"
-                name="firstName"
-                placeholder="First Name"
-                required
-                rules={{
-                  required: { value: true, message: 'First Name is required.' },
-                  maxLength: {
-                    value: 25,
-                    message: 'First Name has a maximum of 25 characters',
-                  },
-                  minLength: {
-                    value: 3,
-                    message: 'First Name requires a minimum of 3 characters.',
-                  },
-                }}
-                formProps={{
-                  ...rest,
-                  control,
-                  formState: { ...formState, isSubmitting },
-                  handleSubmit,
-                  setError,
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} md={3}>
-              <InputField
-                label="Last Name"
-                name="lastName"
-                placeholder="Last Name"
-                rules={{
-                  maxLength: {
-                    value: 30,
-                    message:
-                      'If inputted, Last Name has a maximum of 30 characters',
-                  },
-                  minLength: {
-                    value: 2,
-                    message:
-                      'If inputted, Last Name requires a minimum of 2 characters.',
-                  },
-                }}
-                formProps={{
-                  ...rest,
-                  control,
-                  formState: { ...formState, isSubmitting },
-                  handleSubmit,
-                  setError,
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} md={3}>
-              <InputField
-                label="Email Address"
-                name="email"
-                placeholder="Email Address"
-                type="email"
-                rules={{
-                  pattern: {
-                    value: /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$/,
-                    message: 'Invalid email address.',
-                  },
-                }}
-                formProps={{
-                  ...rest,
-                  control,
-                  formState: { ...formState, isSubmitting },
-                  handleSubmit,
-                  setError,
-                }}
-              />
-            </Grid>
-            <Grid item xs={12} md={3}>
-              <Button
-                disabled={!isErrorsEmpty}
-                fullWidth
-                variant="contained"
-                size="large"
-                type="submit"
-              >
-                Create
-              </Button>
-            </Grid>
-          </Grid>
-          {!isErrorsEmpty && (
-            <Alert sx={{ mt: 2 }} severity="error">
-              <AlertTitle>Error</AlertTitle>
-              {Object.entries(errors).map(([k, v]) => (
-                <Box key={k}>
-                  <Typography>{v?.message}</Typography>
-                </Box>
-              ))}
-            </Alert>
-          )}
-        </Box>
-      </Grid>
-    </Grid>
-  );
+  return <ContactInformation onSubmit={onSubmit} />;
 };
 
 export default CreateContact;

--- a/src/app/edit/contact/[id]/page.tsx
+++ b/src/app/edit/contact/[id]/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import ContactInformation from '@/components/ContactInformation';
+import { DataContext } from '@/context/context';
+import { Contact } from '@/models/contact';
+import { useContext } from 'react';
+import { SubmitHandler } from 'react-hook-form';
+
+const EditContact: React.FC<{ params: { id: string } }> = ({ params }) => {
+  const { contacts } = useContext(DataContext);
+  const id = Number(params.id);
+  const contact = contacts.find((c) => c.id === id);
+
+  const onSubmit: SubmitHandler<Contact> = (data) => {
+    if (!contact) {
+      return;
+    }
+    const { id, email } = contact,
+      { firstName, lastName } = data;
+
+    const updatedContact: Contact = { firstName, lastName, id, email };
+    const contactIndex = contacts.findIndex((c) => c.id === id);
+    contacts[contactIndex] = updatedContact;
+  };
+
+  return (
+    <ContactInformation isEdit id={Number(params.id)} onSubmit={onSubmit} />
+  );
+};
+
+export default EditContact;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useContactContext } from '@/context/context';
+import { Delete, Edit } from '@mui/icons-material';
 import {
   Button,
   Card,
@@ -33,12 +34,18 @@ export default function Home() {
                 <Typography>Email: {c.email}</Typography>
               </CardContent>
               <CardActions>
-                <Button variant="contained" fullWidth>
+                <Button
+                  variant="contained"
+                  fullWidth
+                  startIcon={<Edit />}
+                  onClick={() => router.push(`/edit/contact/${c.id}`)}
+                >
                   Edit Contact
                 </Button>
                 <Button
                   variant="contained"
                   fullWidth
+                  startIcon={<Delete />}
                   onClick={() =>
                     setContacts(contacts.filter((con) => c.id !== con.id))
                   }
@@ -54,6 +61,7 @@ export default function Home() {
         <Button
           variant="contained"
           sx={{ a: { textDecoration: 'none', color: 'inherit' } }}
+          startIcon={<Edit />}
           onClick={() => router.push('/create/contact')}
         >
           <Link href="/create/contact">Create New Contact</Link>

--- a/src/components/ContactInformation.tsx
+++ b/src/components/ContactInformation.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { InputField } from '@/components/InputField';
+import { DataContext } from '@/context/context';
+import { Contact } from '@/models/contact';
+import { emailRules, firstNameRules, lastNameRules } from '@/utils/utils';
+import { Close } from '@mui/icons-material';
+import {
+  Alert,
+  AlertTitle,
+  Box,
+  Button,
+  Collapse,
+  Grid,
+  IconButton,
+  Typography,
+} from '@mui/material';
+import React, { useContext, useEffect, useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+export const ContactInformation: React.FC<{
+  onSubmit: SubmitHandler<Contact>;
+  isEdit?: boolean;
+  id?: number;
+}> = ({ isEdit = false, id, onSubmit }) => {
+  const { contacts } = useContext(DataContext);
+  const [open, setOpen] = useState(false);
+  const contact = contacts.find((c) => c.id === id);
+  const formReturnValues = useForm<Contact>({
+    defaultValues: {
+      firstName: isEdit ? contact?.firstName : '',
+      lastName: isEdit ? contact?.lastName : '',
+      email: isEdit ? contact?.email : '',
+    },
+  });
+
+  const { formState, handleSubmit, setError, control, ...rest } =
+    formReturnValues;
+  const { isSubmitting, errors } = formState;
+
+  const submit = (data: Contact) => {
+    setOpen(false);
+    for (let c of contacts) {
+      if (c.email === data.email) {
+        setError('email', { type: 'custom', message: 'Email exists' });
+        return;
+      }
+    }
+    onSubmit(data);
+    setOpen(true);
+  };
+
+  const isErrorsEmpty = Object.keys(errors).length === 0;
+  useEffect(() => {
+    if (!isErrorsEmpty && open) {
+      setOpen(false);
+    }
+  }, [isErrorsEmpty, open]);
+  const formProps = {
+    ...rest,
+    control,
+    formState: { ...formState, isSubmitting },
+    handleSubmit,
+    setError,
+  };
+
+  return (
+    <Grid container>
+      <Grid item xs={12}>
+        <Typography variant="h1">
+          {isEdit ? 'Edit Contact' : 'Create New Contact'}
+        </Typography>
+        <Box component="form" width="100%" onSubmit={handleSubmit(submit)}>
+          <Grid
+            container
+            spacing={2}
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <Grid item xs={12} md={3}>
+              <InputField
+                label="First Name"
+                name="firstName"
+                placeholder="First Name"
+                required
+                rules={firstNameRules}
+                formProps={formProps}
+              />
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <InputField
+                label="Last Name"
+                name="lastName"
+                placeholder="Last Name"
+                rules={lastNameRules}
+                formProps={formProps}
+              />
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <InputField
+                label="Email Address"
+                name="email"
+                placeholder="Email Address"
+                type="email"
+                disabled={isEdit}
+                required
+                rules={emailRules}
+                formProps={formProps}
+              />
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <Button
+                disabled={!isErrorsEmpty}
+                fullWidth
+                variant="contained"
+                size="large"
+                type="submit"
+              >
+                {isEdit ? 'Submit' : 'Create'}
+              </Button>
+            </Grid>
+            <Grid item xs={12}>
+              <Collapse in={open && isErrorsEmpty}>
+                <Alert
+                  action={
+                    <IconButton
+                      aria-label="close"
+                      color="inherit"
+                      size="small"
+                      onClick={() => setOpen(false)}
+                    >
+                      <Close fontSize="inherit" />
+                    </IconButton>
+                  }
+                  sx={{ mb: 2 }}
+                >
+                  <AlertTitle>Success</AlertTitle>
+                  {isEdit ? 'Contact Updated!' : 'Contact Created!'}
+                </Alert>
+              </Collapse>
+            </Grid>
+          </Grid>
+          {!isErrorsEmpty && (
+            <Alert sx={{ mt: 2 }} severity="error">
+              <AlertTitle>Error</AlertTitle>
+              {Object.entries(errors).map(([k, v]) => (
+                <Box key={k}>
+                  <Typography>{v?.message}</Typography>
+                </Box>
+              ))}
+            </Alert>
+          )}
+        </Box>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default ContactInformation;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,32 @@
+export const firstNameRules = {
+  required: {
+    value: true,
+    message: 'First Name is required.',
+  },
+  maxLength: {
+    value: 25,
+    message: 'First Name has a maximum of 25 characters',
+  },
+  minLength: {
+    value: 3,
+    message: 'First Name requires a minimum of 3 characters.',
+  },
+};
+
+export const lastNameRules = {
+  maxLength: {
+    value: 30,
+    message: 'If inputted, Last Name has a maximum of 30 characters',
+  },
+  minLength: {
+    value: 2,
+    message: 'If inputted, Last Name requires a minimum of 2 characters.',
+  },
+};
+
+export const emailRules = {
+  pattern: {
+    value: /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$/,
+    message: 'Invalid email address.',
+  },
+};


### PR DESCRIPTION
## Changes
- Updated Readme file with instructions.
- Updated `Home` component to route to `Edit` page on edit button. Updated buttons to have icons as well.
- Refactored initial `CreateContact` component to `ContactInformation` as `CreateContact` and `EditContact` used the same components with slight alterations.
- Created `EditContact` component to handle `EditingContact`.
- Create `utils` file holding the appropriate rules for the different fields. They are being re-used on both `Create` and `Edit` contact components.

## Images

**Image 1: ** Main Page - Buttons with icons.
![Screenshot 2024-02-16 at 15 06 13](https://github.com/mattzbik/contact-management-react/assets/10634184/dca7019c-9a35-44a6-bc2c-5196819ac3c0)
Page Buttons with Icons.

**Image 2:** Edit Contact Page - Notice `Email Address` is disabled.

![Screenshot 2024-02-16 at 15 06 22](https://github.com/mattzbik/contact-management-react/assets/10634184/e53ccd68-f8e7-453a-963f-f15483ae24b0)

**Image 3:** Success Alert on submit.
![Screenshot 2024-02-16 at 15 06 27](https://github.com/mattzbik/contact-management-react/assets/10634184/aebdcade-784d-44e9-b8d1-06548381cd51)

**Image 4: ** Error Alert on submit, contact will fail to save.
![Screenshot 2024-02-16 at 15 06 42](https://github.com/mattzbik/contact-management-react/assets/10634184/e157d4ed-ddaa-464c-ba69-8d5f77f9df77)

